### PR TITLE
reMap als Mapper aufgenommen

### DIFF
--- a/bean-mapper-test/pom.xml
+++ b/bean-mapper-test/pom.xml
@@ -82,6 +82,11 @@
 			<artifactId>selma-processor</artifactId>
 			<scope>provided</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.remondis</groupId>
+			<artifactId>remap</artifactId>
+			<version>1.0.3</version>
+		</dependency>
 
 		<!-- Tests -->
 		<dependency>

--- a/bean-mapper-test/src/main/java/de/rahn/performance/beanmapper/vendors/ReMapTestBeansMapperBean.java
+++ b/bean-mapper-test/src/main/java/de/rahn/performance/beanmapper/vendors/ReMapTestBeansMapperBean.java
@@ -15,6 +15,38 @@ import org.springframework.stereotype.Component;
 @Component
 public class ReMapTestBeansMapperBean implements TestBeansMapperBean {
 
+  private Mapper<XmlRow, DomainRow> xmlRowToDomainRowMapper;
+
+  private Mapper<XmlTable, DomainTable> xmlTableToDomainTableMapper;
+
+  private Mapper<DomainRow, XmlRow> domainRowToXmlRowMapper;
+
+  private Mapper<DomainTable, XmlTable> domainTableToXmlTableMapper;
+
+  public ReMapTestBeansMapperBean() {
+    this.xmlRowToDomainRowMapper = Mapping
+        .from(XmlRow.class)
+        .to(DomainRow.class)
+        .mapper();
+    this.xmlTableToDomainTableMapper = Mapping
+        .from(XmlTable.class)
+        .to(DomainTable.class)
+        .replace(XmlTable::getDate, DomainTable::getDate)
+        .with(calendarToDate())
+        .useMapper(xmlRowToDomainRowMapper)
+        .mapper();
+    this.domainRowToXmlRowMapper = Mapping
+        .from(DomainRow.class)
+        .to(XmlRow.class)
+        .mapper();
+    this.domainTableToXmlTableMapper = Mapping.from(DomainTable.class)
+        .to(XmlTable.class)
+        .replace(DomainTable::getDate, XmlTable::getDate)
+        .with(dateToCalendar())
+        .useMapper(this.domainRowToXmlRowMapper)
+        .mapper();
+  }
+
   @Override
   public String getMapperName() {
     return "reMap";
@@ -22,41 +54,17 @@ public class ReMapTestBeansMapperBean implements TestBeansMapperBean {
 
   @Override
   public XmlTable map(DomainTable source) throws Exception {
-    Mapper<DomainRow, XmlRow> rowMapper =
-        Mapping.from(DomainRow.class)
-            .to(XmlRow.class)
-            .mapper();
-
-    Mapper<DomainTable, XmlTable> tableMapper = Mapping.from(DomainTable.class)
-        .to(XmlTable.class)
-        .replace(DomainTable::getDate, XmlTable::getDate)
-        .with(dateToCalendar())
-        .useMapper(rowMapper)
-        .mapper();
-
-    return tableMapper.map(source);
+    return domainTableToXmlTableMapper.map(source);
   }
 
   @Override
   public DomainTable map(XmlTable source) throws Exception {
-    Mapper<XmlRow, DomainRow> rowMapper =
-        Mapping.from(XmlRow.class)
-            .to(DomainRow.class)
-            .mapper();
-
-    Mapper<XmlTable, DomainTable> tableMapper = Mapping.from(XmlTable.class)
-        .to(DomainTable.class)
-        .replace(XmlTable::getDate, DomainTable::getDate)
-        .with(calendarToDate())
-        .useMapper(rowMapper)
-        .mapper();
-
-    return tableMapper.map(source);
+    return xmlTableToDomainTableMapper.map(source);
   }
 
   private Transform<Calendar, Date> dateToCalendar() {
     return source -> {
-      if(source == null){
+      if (source == null) {
         return null;
       }
       Calendar c = Calendar.getInstance();
@@ -67,7 +75,7 @@ public class ReMapTestBeansMapperBean implements TestBeansMapperBean {
 
   private Transform<Date, Calendar> calendarToDate() {
     return source -> {
-      if(source == null){
+      if (source == null) {
         return null;
       }
       return source.getTime();

--- a/bean-mapper-test/src/main/java/de/rahn/performance/beanmapper/vendors/ReMapTestBeansMapperBean.java
+++ b/bean-mapper-test/src/main/java/de/rahn/performance/beanmapper/vendors/ReMapTestBeansMapperBean.java
@@ -1,0 +1,76 @@
+package de.rahn.performance.beanmapper.vendors;
+
+import com.remondis.remap.Mapper;
+import com.remondis.remap.Mapping;
+import com.remondis.remap.Transform;
+import de.frank_rahn.xmlns.types.testtypes._1.XmlRow;
+import de.frank_rahn.xmlns.types.testtypes._1.XmlTable;
+import de.rahn.performance.beanmapper.TestBeansMapperBean;
+import de.rahn.performance.testbeans.DomainRow;
+import de.rahn.performance.testbeans.DomainTable;
+import java.util.Calendar;
+import java.util.Date;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ReMapTestBeansMapperBean implements TestBeansMapperBean {
+
+  @Override
+  public String getMapperName() {
+    return "reMap";
+  }
+
+  @Override
+  public XmlTable map(DomainTable source) throws Exception {
+    Mapper<DomainRow, XmlRow> rowMapper =
+        Mapping.from(DomainRow.class)
+            .to(XmlRow.class)
+            .mapper();
+
+    Mapper<DomainTable, XmlTable> tableMapper = Mapping.from(DomainTable.class)
+        .to(XmlTable.class)
+        .replace(DomainTable::getDate, XmlTable::getDate)
+        .with(dateToCalendar())
+        .useMapper(rowMapper)
+        .mapper();
+
+    return tableMapper.map(source);
+  }
+
+  @Override
+  public DomainTable map(XmlTable source) throws Exception {
+    Mapper<XmlRow, DomainRow> rowMapper =
+        Mapping.from(XmlRow.class)
+            .to(DomainRow.class)
+            .mapper();
+
+    Mapper<XmlTable, DomainTable> tableMapper = Mapping.from(XmlTable.class)
+        .to(DomainTable.class)
+        .replace(XmlTable::getDate, DomainTable::getDate)
+        .with(calendarToDate())
+        .useMapper(rowMapper)
+        .mapper();
+
+    return tableMapper.map(source);
+  }
+
+  private Transform<Calendar, Date> dateToCalendar() {
+    return source -> {
+      if(source == null){
+        return null;
+      }
+      Calendar c = Calendar.getInstance();
+      c.setTime(source);
+      return c;
+    };
+  }
+
+  private Transform<Date, Calendar> calendarToDate() {
+    return source -> {
+      if(source == null){
+        return null;
+      }
+      return source.getTime();
+    };
+  }
+}

--- a/bean-mapper-test/src/test/java/de/rahn/performance/beanmapper/vendors/ReMapTestBeansMapperBeanTest.java
+++ b/bean-mapper-test/src/test/java/de/rahn/performance/beanmapper/vendors/ReMapTestBeansMapperBeanTest.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright © 2014 by Frank W. Rahn. Alle Rechte vorbehalten. All rights
+ * reserved.
+ */
+package de.rahn.performance.beanmapper.vendors;
+
+import org.junit.Before;
+
+public class ReMapTestBeansMapperBeanTest extends AbstractTestBeansMapperBeanTest {
+
+  @Before
+  public void setUp() throws Exception {
+    mapperBean = new ReMapTestBeansMapperBean();
+  }
+
+}


### PR DESCRIPTION
Ich war an der Geschwindigkeit unseres Mappers [reMap](https://github.com/remondis-it/remap) interessiert und habe ihr Framework für den Vergleich mit den anderen Mappern genutzt. Da die Arbeit jetzt schon getan ist, stelle ich sie in diesem Pull Request zur Verfügung und würde mich freuen, wenn der Mapper mit aufgenommen wird.